### PR TITLE
carac: nuevo comando para ejecutar typescript con ts-node-dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "rm -rf dist/ && tsc",
     "start": "node ./dist/index.js",
+    "start:dev":"ts-node-dev --respawn src/index.ts",
     "dev": "concurrently \"npx tsc --watch\" \"nodemon -q dist/index.js\""
   },
   "keywords": [],
@@ -29,6 +30,7 @@
     "@types/node": "^18.7.16",
     "concurrently": "^7.4.0",
     "nodemon": "^2.0.19",
+    "ts-node-dev": "^2.0.0",
     "typescript": "^4.8.3"
   }
 }


### PR DESCRIPTION
Con el comando npm run dev obtengo un error que me obliga a parar y eejcutar de nuevo el comando, le agregue un nuevo comando para usar ts-node-dev para ejecutar codigo TS y reload automatico cuando cambia el codigo.